### PR TITLE
feat: add automated Renovate PR handling with Claude

### DIFF
--- a/.github/workflows/claude-renovate.yml
+++ b/.github/workflows/claude-renovate.yml
@@ -56,7 +56,7 @@ jobs:
               });
               
               const hasFailingChecks = checkRuns.check_runs.some(run => 
-                run.conclusion === 'failure' && run.name !== 'Claude Renovate PR Handler'
+                run.conclusion === 'failure' && !run.name.includes('Claude')
               );
               
               if (!hasFailingChecks) continue;
@@ -86,6 +86,9 @@ jobs:
       - name: Auto-comment with Claude mention
         if: github.event_name == 'pull_request' || steps.find-prs.outputs.pr_number != ''
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.find-prs.outputs.pr_number || '0' }}
+          PR_DATA: ${{ steps.find-prs.outputs.pr_data || '{}' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -94,11 +97,11 @@ jobs:
               pr = context.payload.pull_request;
               prNumber = pr.number;
             } else {
-              // Scheduled run - get PR data from previous step
-              prNumber = ${{ steps.find-prs.outputs.pr_number || 0 }};
+              // Scheduled run - get PR data from environment variables
+              prNumber = parseInt(process.env.PR_NUMBER);
               if (!prNumber) return; // No PRs to process
               
-              const prData = ${{ steps.find-prs.outputs.pr_data || '{}' }};
+              const prData = process.env.PR_DATA;
               pr = JSON.parse(prData);
               
               // Fetch full PR details including body
@@ -124,21 +127,37 @@ jobs:
               oldVersion = `${oldMajor}.${oldMinor}.${oldPatch}`;
               newVersion = `${newMajor}.${newMinor}.${newPatch}`;
               
-              if (newMajor > oldMajor) {
+              if (parseInt(newMajor) > parseInt(oldMajor)) {
                 updateType = 'MAJOR';
-              } else if (newMinor > oldMinor) {
+              } else if (parseInt(newMinor) > parseInt(oldMinor)) {
                 updateType = 'MINOR';
-              } else if (newPatch > oldPatch) {
+              } else if (parseInt(newPatch) > parseInt(oldPatch)) {
                 updateType = 'PATCH';
               }
             }
             
             // Extract merge confidence level from badges
-            const confidenceMatch = prBody.match(/confidence\/npm\/[^/]+\/[^/]+\/[^?]+/);
-            const hasHighConfidence = prBody.includes('confidence') && 
-                                    (prBody.includes('high') || prBody.includes('very-high'));
-            const hasLowConfidence = prBody.includes('confidence') && 
-                                   (prBody.includes('low') || prBody.includes('very-low'));
+            // Look for confidence badge URL pattern or confidence text in PR
+            const confidenceBadgeMatch = prBody.match(/confidence\/npm\/[^/]+\/[^/]+\/([^?]+)/);
+            const confidenceTextMatch = prBody.match(/confidence[^|]*\|[^|]*\|[^|]*\|[^|]*(?:high|low|neutral|very-high|very-low)/i);
+            
+            let confidenceLevel = 'unknown';
+            let hasHighConfidence = false;
+            let hasLowConfidence = false;
+            
+            // Check badge URL for confidence level
+            if (confidenceBadgeMatch && confidenceBadgeMatch[1]) {
+              const confidence = confidenceBadgeMatch[1].toLowerCase();
+              hasHighConfidence = confidence.includes('high');
+              hasLowConfidence = confidence.includes('low');
+              confidenceLevel = confidence;
+            } 
+            // Fallback to checking PR text
+            else if (confidenceTextMatch) {
+              const match = confidenceTextMatch[0].toLowerCase();
+              hasHighConfidence = match.includes('high');
+              hasLowConfidence = match.includes('low');
+            }
             
             let comment = `@claude This is an automated Renovate dependency update PR.
             

--- a/.github/workflows/claude-renovate.yml
+++ b/.github/workflows/claude-renovate.yml
@@ -149,7 +149,7 @@ jobs:
             // Extract merge confidence level from badges
             // Look for confidence badge URL pattern or confidence text in PR
             const confidenceBadgeMatch = prBody.match(/confidence\/npm\/[^/]+\/[^/]+\/([^?]+)/);
-            const confidenceTextMatch = prBody.match(/confidence[^|]*\|[^|]*\|[^|]*\|[^|]*(?:high|low|neutral|very-high|very-low)/i);
+            const confidenceTextMatch = prBody.match(/\b(very-high|high|neutral|low|very-low)\b/i);
             
             let confidenceLevel = 'unknown';
             let hasHighConfidence = false;

--- a/.github/workflows/claude-renovate.yml
+++ b/.github/workflows/claude-renovate.yml
@@ -1,0 +1,71 @@
+name: Claude Renovate PR Handler
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  handle-renovate-pr:
+    if: github.actor == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          
+      - name: Auto-comment with Claude mention
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const prBody = pr.body || '';
+            
+            // Extract update type and package info from PR title/body
+            const isMinorPatch = prBody.includes('minor') || prBody.includes('patch');
+            const isMajor = prBody.includes('major');
+            
+            let comment = `@claude This is an automated Renovate dependency update PR.
+            
+            **IMPORTANT**: Follow the Renovate PR handling instructions in CLAUDE.md section "## Renovate PR Handling".
+            
+            **PR Details:**
+            - Update Type: ${isMajor ? 'MAJOR' : isMinorPatch ? 'MINOR/PATCH' : 'UNKNOWN'}
+            - PR Title: ${pr.title}
+            
+            **Your Tasks:**
+            1. First, read the "Renovate PR Handling" section in CLAUDE.md for detailed instructions
+            2. Run \`pnpm run ci\` to check if the update causes any issues
+            3. Based on the update type and CI results:
+               - For MINOR/PATCH: Fix any linting/test failures and approve for auto-merge
+               - For MAJOR: Check the CHANGELOG or release notes (linked in PR description) for breaking changes
+               - If breaking changes don't affect our usage, fix any issues and approve
+               - If you need human decision, mention @eins78 with:
+                 - Summary of breaking changes
+                 - How they might affect our code
+                 - Your recommendation
+            
+            **Remember**: 
+            - Always ensure CI is green before approving
+            - Check CLAUDE.md for specific package handling rules
+            - When in doubt, ask @eins78`;
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: comment
+            });
+            
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          timeout_minutes: "60"

--- a/.github/workflows/claude-renovate.yml
+++ b/.github/workflows/claude-renovate.yml
@@ -34,28 +34,23 @@ jobs:
             
             let comment = `@claude This is an automated Renovate dependency update PR.
             
-            **IMPORTANT**: Follow the Renovate PR handling instructions in CLAUDE.md section "## Renovate PR Handling".
+            **IMPORTANT**: Read RENOVATE.md for complete instructions on handling dependency updates.
             
             **PR Details:**
             - Update Type: ${isMajor ? 'MAJOR' : isMinorPatch ? 'MINOR/PATCH' : 'UNKNOWN'}
             - PR Title: ${pr.title}
             
-            **Your Tasks:**
-            1. First, read the "Renovate PR Handling" section in CLAUDE.md for detailed instructions
-            2. Run \`pnpm run ci\` to check if the update causes any issues
-            3. Based on the update type and CI results:
-               - For MINOR/PATCH: Fix any linting/test failures and approve for auto-merge
-               - For MAJOR: Check the CHANGELOG or release notes (linked in PR description) for breaking changes
-               - If breaking changes don't affect our usage, fix any issues and approve
-               - If you need human decision, mention @eins78 with:
-                 - Summary of breaking changes
-                 - How they might affect our code
-                 - Your recommendation
+            **Quick Summary:**
+            1. Read RENOVATE.md for the complete workflow
+            2. Work on this ONE PR only (don't touch other Renovate PRs)
+            3. Either fix and merge OR skip with @eins78 mention
+            4. Use Dependency Dashboard to request next PR
+            5. Continue until ALL updates are handled
             
-            **Remember**: 
-            - Always ensure CI is green before approving
-            - Check CLAUDE.md for specific package handling rules
-            - When in doubt, ask @eins78`;
+            **Key Rules:**
+            - Never work on multiple PRs (pnpm lockfile conflicts)
+            - Process every update until Dashboard is clear
+            - Follow the skip criteria in RENOVATE.md section 4`;
             
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/claude-renovate.yml
+++ b/.github/workflows/claude-renovate.yml
@@ -24,13 +24,15 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - name: Checkout repository
+      # For PR events, checkout the PR branch immediately
+      - name: Checkout PR branch
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || 'main' }}
+          ref: ${{ github.event.pull_request.head.ref }}
           
-      # For scheduled runs, find open Renovate PRs that need attention
+      # For scheduled runs, find open Renovate PRs that need attention first
       - name: Find Renovate PRs needing attention
         if: github.event_name == 'schedule'
         id: find-prs
@@ -82,6 +84,14 @@ jobs:
             }
             
             core.setOutput('pr_number', '');
+          
+      # For scheduled runs, checkout the PR branch after finding it
+      - name: Checkout PR branch for scheduled run
+        if: github.event_name == 'schedule' && steps.find-prs.outputs.pr_number != ''
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ fromJson(steps.find-prs.outputs.pr_data).head.ref }}
           
       - name: Auto-comment with Claude mention
         if: github.event_name == 'pull_request' || steps.find-prs.outputs.pr_number != ''

--- a/.github/workflows/claude-renovate.yml
+++ b/.github/workflows/claude-renovate.yml
@@ -28,17 +28,42 @@ jobs:
             const pr = context.payload.pull_request;
             const prBody = pr.body || '';
             
-            // Extract update type and package info from PR title/body
-            const isMinorPatch = prBody.includes('minor') || prBody.includes('patch');
-            const isMajor = prBody.includes('major');
+            // Parse version table from PR description
+            // Example: | package | `1.2.3` -> `2.0.0` | age | confidence |
+            const versionMatch = prBody.match(/\|\s*`(\d+)\.(\d+)\.(\d+)`\s*->\s*`(\d+)\.(\d+)\.(\d+)`\s*\|/);
+            let updateType = 'UNKNOWN';
+            let oldVersion = '';
+            let newVersion = '';
+            
+            if (versionMatch) {
+              const [, oldMajor, oldMinor, oldPatch, newMajor, newMinor, newPatch] = versionMatch;
+              oldVersion = `${oldMajor}.${oldMinor}.${oldPatch}`;
+              newVersion = `${newMajor}.${newMinor}.${newPatch}`;
+              
+              if (newMajor > oldMajor) {
+                updateType = 'MAJOR';
+              } else if (newMinor > oldMinor) {
+                updateType = 'MINOR';
+              } else if (newPatch > oldPatch) {
+                updateType = 'PATCH';
+              }
+            }
+            
+            // Extract merge confidence level from badges
+            const confidenceMatch = prBody.match(/confidence\/npm\/[^/]+\/[^/]+\/[^?]+/);
+            const hasHighConfidence = prBody.includes('confidence') && 
+                                    (prBody.includes('high') || prBody.includes('very-high'));
+            const hasLowConfidence = prBody.includes('confidence') && 
+                                   (prBody.includes('low') || prBody.includes('very-low'));
             
             let comment = `@claude This is an automated Renovate dependency update PR.
             
             **IMPORTANT**: Read RENOVATE.md for complete instructions on handling dependency updates.
             
             **PR Details:**
-            - Update Type: ${isMajor ? 'MAJOR' : isMinorPatch ? 'MINOR/PATCH' : 'UNKNOWN'}
+            - Update Type: **${updateType}**${oldVersion && newVersion ? ` (${oldVersion} → ${newVersion})` : ''}
             - PR Title: ${pr.title}
+            - Merge Confidence: ${hasHighConfidence ? '✅ HIGH' : hasLowConfidence ? '⚠️ LOW' : '➖ NEUTRAL/UNKNOWN'}
             
             **Quick Summary:**
             1. Read RENOVATE.md for the complete workflow
@@ -46,6 +71,13 @@ jobs:
             3. Either fix and merge OR skip with @eins78 mention
             4. Use Dependency Dashboard to request next PR
             5. Continue until ALL updates are handled
+            
+            **Decision Hints:**
+            ${updateType === 'PATCH' ? '- PATCH update: Usually safe, fix CI and merge' : ''}
+            ${updateType === 'MINOR' ? '- MINOR update: Check for deprecations, usually safe' : ''}
+            ${updateType === 'MAJOR' ? '- MAJOR update: Check changelog for breaking changes!' : ''}
+            ${hasHighConfidence ? '- High merge confidence: Lower risk of issues' : ''}
+            ${hasLowConfidence ? '- Low merge confidence: Extra caution needed, review carefully' : ''}
             
             **Key Rules:**
             - Never work on multiple PRs (pnpm lockfile conflicts)

--- a/.github/workflows/claude-renovate.yml
+++ b/.github/workflows/claude-renovate.yml
@@ -3,10 +3,20 @@ name: Claude Renovate PR Handler
 on:
   pull_request:
     types: [opened, synchronize]
+  schedule:
+    # Run every hour to check for Renovate PRs that need attention
+    - cron: '0 * * * *'
+
+# Prevent multiple runs from happening at the same time
+concurrency:
+  group: claude-renovate
+  cancel-in-progress: false
 
 jobs:
   handle-renovate-pr:
-    if: github.actor == 'renovate[bot]'
+    # For PR events: only run if actor is renovate[bot]
+    # For schedule: always run
+    if: github.event_name == 'schedule' || github.actor == 'renovate[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -18,14 +28,88 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || 'main' }}
           
-      - name: Auto-comment with Claude mention
+      # For scheduled runs, find open Renovate PRs that need attention
+      - name: Find Renovate PRs needing attention
+        if: github.event_name == 'schedule'
+        id: find-prs
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const pr = context.payload.pull_request;
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+            
+            // Find Renovate PRs with failing CI or without recent Claude activity
+            const renovatePRs = prs.filter(pr => pr.user.login === 'renovate[bot]');
+            
+            for (const pr of renovatePRs) {
+              // Check if CI is failing
+              const { data: checkRuns } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: pr.head.sha
+              });
+              
+              const hasFailingChecks = checkRuns.check_runs.some(run => 
+                run.conclusion === 'failure' && run.name !== 'Claude Renovate PR Handler'
+              );
+              
+              if (!hasFailingChecks) continue;
+              
+              // Check last Claude comment
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number
+              });
+              
+              const lastClaudeComment = comments
+                .filter(c => c.body.includes('@claude'))
+                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+              
+              // If no Claude comment in last 2 hours, we should process this PR
+              const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+              if (!lastClaudeComment || new Date(lastClaudeComment.created_at) < twoHoursAgo) {
+                core.setOutput('pr_number', pr.number);
+                core.setOutput('pr_data', JSON.stringify(pr));
+                return; // Process first PR found
+              }
+            }
+            
+            core.setOutput('pr_number', '');
+          
+      - name: Auto-comment with Claude mention
+        if: github.event_name == 'pull_request' || steps.find-prs.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let pr, prNumber;
+            if (context.eventName === 'pull_request') {
+              pr = context.payload.pull_request;
+              prNumber = pr.number;
+            } else {
+              // Scheduled run - get PR data from previous step
+              prNumber = ${{ steps.find-prs.outputs.pr_number || 0 }};
+              if (!prNumber) return; // No PRs to process
+              
+              const prData = ${{ steps.find-prs.outputs.pr_data || '{}' }};
+              pr = JSON.parse(prData);
+              
+              // Fetch full PR details including body
+              const { data: fullPR } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              pr = fullPR;
+            }
+            
             const prBody = pr.body || '';
             
             // Parse version table from PR description
@@ -84,14 +168,20 @@ jobs:
             - Process every update until Dashboard is clear
             - Follow the skip criteria in RENOVATE.md section 4`;
             
+            // Add note if this is a scheduled re-run
+            if (context.eventName === 'schedule') {
+              comment = `**[Scheduled Check]** CI is still failing, attempting to fix:\n\n` + comment;
+            }
+            
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: pr.number,
+              issue_number: prNumber,
               body: comment
             });
             
       - name: Run Claude PR Action
+        if: github.event_name == 'pull_request' || steps.find-prs.outputs.pr_number != ''
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,7 +382,21 @@ When handling automated Renovate PRs, follow these guidelines:
 - Look for breaking changes section in PR body
 - Check linked changelog/release notes
 
-### 2. Automated Approval Criteria
+### 2. 🚨 CRITICAL: One PR at a Time Rule
+
+**Due to pnpm lockfile conflicts, you MUST only work on ONE dependency update at a time:**
+
+1. **Never work on multiple Renovate PRs simultaneously**
+2. **Never request rebase for more than one PR**
+3. **Follow this workflow:**
+   - Work on one PR until it's either merged or skipped
+   - Only after completion, use the Dependency Dashboard issue
+   - Check the box to request the next update or rebase
+   - Wait for the new PR before starting work
+
+**Why this matters:** Every dependency update modifies the pnpm lockfile, causing merge conflicts with all other update PRs. Working on multiple PRs wastes effort as only one can be merged.
+
+### 3. Automated Approval Criteria
 
 #### Auto-approve and merge if ALL conditions are met:
 - Update type is minor or patch
@@ -398,7 +412,7 @@ When handling automated Renovate PRs, follow these guidelines:
    - You can fix any issues that arise
    - Changes are well-documented
 
-### 3. Special Package Rules
+### 4. Special Package Rules
 
 #### High Priority Packages (always review carefully):
 - `lit`, `@lit/*`, `@lit-labs/*` - Core framework, check for API changes
@@ -413,7 +427,7 @@ When handling automated Renovate PRs, follow these guidelines:
 - License changes
 - Packages not in our approved list
 
-### 4. Fix Process
+### 5. Fix Process
 1. Run `pnpm install` to update lockfile
 2. Run `pnpm run ci` to check everything
 3. Fix issues in this order:
@@ -422,8 +436,12 @@ When handling automated Renovate PRs, follow these guidelines:
    - Test failures
 4. Commit fixes with message: "fix: resolve issues from {package} update"
 5. Ensure CI is green before approving
+6. After PR is merged or skipped:
+   - Go to the Dependency Dashboard issue
+   - Check the box for the next update to process
+   - Wait for Renovate to create/rebase the PR
 
-### 5. Example Escalation Comment
+### 6. Example Escalation Comment
 ```
 @eins78 I need your input on this update:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,6 +377,16 @@ act  # Requires act tool to run GitHub Actions locally
 
 When handling automated Renovate PRs, follow these guidelines:
 
+### 🎯 Ultimate Goal
+
+**Your mission: Process ALL pending dependency updates until the Dependency Dashboard is clear.**
+
+- Continue working through PRs one by one until every update is either:
+  - ✅ Merged (CI green, no issues)
+  - ⏭️ Skipped (escalated to @eins78)
+- Do NOT stop work until all updates are handled
+- The Dependency Dashboard should show zero pending updates when you're done
+
 ### 1. Identify Update Type
 - Check the PR description for update type (major/minor/patch)
 - Look for breaking changes section in PR body
@@ -420,12 +430,22 @@ When handling automated Renovate PRs, follow these guidelines:
 - `eslint` and plugins - May add new rules requiring fixes
 - `playwright` - Check for API changes in test code
 
-#### When to Escalate to @eins78:
-- Breaking changes that require architectural decisions
-- Security-related updates with unclear impact
-- Updates that fail after multiple fix attempts
-- License changes
-- Packages not in our approved list
+#### When to Skip (Escalate to @eins78):
+
+**Skip the PR and mention @eins78 when:**
+- Breaking changes require architectural decisions (e.g., API redesign, migration strategy)
+- Security updates have unclear impact on our application
+- After 3 attempts, you cannot make CI green
+- License changes from permissive to restrictive
+- Package is not in our dependencies (might be a new sub-dependency)
+- Update requires manual testing that you cannot perform
+- Breaking changes affect core business logic you're unsure about
+
+**When you skip:** 
+1. Comment with the escalation format (see example below)
+2. Do NOT close or dismiss the PR
+3. Move to the next update via Dependency Dashboard
+4. Continue processing other updates
 
 ### 5. Fix Process
 1. Run `pnpm install` to update lockfile
@@ -456,6 +476,18 @@ When handling automated Renovate PRs, follow these guidelines:
 
 **Recommendation**: [Approve/Delay/Skip] because...
 ```
+
+### 7. Complete Workflow Summary
+
+1. **Start**: Check Dependency Dashboard for pending updates
+2. **Process**: Work on ONE PR at a time:
+   - Try to fix and merge (for safe updates)
+   - Or skip with @eins78 mention (for complex updates)
+3. **Next**: Via Dependency Dashboard, request next PR
+4. **Repeat**: Continue until Dashboard shows zero pending updates
+5. **Done**: All dependencies are either updated or escalated
+
+**Remember**: Your work is NOT complete until every single update is handled!
 
 ## Getting Help
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,119 +375,13 @@ act  # Requires act tool to run GitHub Actions locally
 
 ## Renovate PR Handling
 
-When handling automated Renovate PRs, follow these guidelines:
+For automated Renovate dependency update PRs, see [RENOVATE.md](./RENOVATE.md) for detailed instructions.
 
-### 🎯 Ultimate Goal
-
-**Your mission: Process ALL pending dependency updates until the Dependency Dashboard is clear.**
-
-- Continue working through PRs one by one until every update is either:
-  - ✅ Merged (CI green, no issues)
-  - ⏭️ Skipped (escalated to @eins78)
-- Do NOT stop work until all updates are handled
-- The Dependency Dashboard should show zero pending updates when you're done
-
-### 1. Identify Update Type
-- Check the PR description for update type (major/minor/patch)
-- Look for breaking changes section in PR body
-- Check linked changelog/release notes
-
-### 2. 🚨 CRITICAL: One PR at a Time Rule
-
-**Due to pnpm lockfile conflicts, you MUST only work on ONE dependency update at a time:**
-
-1. **Never work on multiple Renovate PRs simultaneously**
-2. **Never request rebase for more than one PR**
-3. **Follow this workflow:**
-   - Work on one PR until it's either merged or skipped
-   - Only after completion, use the Dependency Dashboard issue
-   - Check the box to request the next update or rebase
-   - Wait for the new PR before starting work
-
-**Why this matters:** Every dependency update modifies the pnpm lockfile, causing merge conflicts with all other update PRs. Working on multiple PRs wastes effort as only one can be merged.
-
-### 3. Automated Approval Criteria
-
-#### Auto-approve and merge if ALL conditions are met:
-- Update type is minor or patch
-- All CI checks pass (after your fixes)
-- No breaking changes mentioned
-- Not in the special handling list below
-
-#### For Major Updates:
-1. Always check the linked changelog/release notes
-2. Search codebase for usage of changed APIs
-3. Auto-approve if:
-   - Breaking changes don't affect our code
-   - You can fix any issues that arise
-   - Changes are well-documented
-
-### 4. Special Package Rules
-
-#### High Priority Packages (always review carefully):
-- `lit`, `@lit/*`, `@lit-labs/*` - Core framework, check for API changes
-- `typescript` - May introduce new strict checks
-- `eslint` and plugins - May add new rules requiring fixes
-- `playwright` - Check for API changes in test code
-
-#### When to Skip (Escalate to @eins78):
-
-**Skip the PR and mention @eins78 when:**
-- Breaking changes require architectural decisions (e.g., API redesign, migration strategy)
-- Security updates have unclear impact on our application
-- After 3 attempts, you cannot make CI green
-- License changes from permissive to restrictive
-- Package is not in our dependencies (might be a new sub-dependency)
-- Update requires manual testing that you cannot perform
-- Breaking changes affect core business logic you're unsure about
-
-**When you skip:** 
-1. Comment with the escalation format (see example below)
-2. Do NOT close or dismiss the PR
-3. Move to the next update via Dependency Dashboard
-4. Continue processing other updates
-
-### 5. Fix Process
-1. Run `pnpm install` to update lockfile
-2. Run `pnpm run ci` to check everything
-3. Fix issues in this order:
-   - TypeScript errors
-   - Linting issues (use `pnpm run lint:eslint -- --fix`)
-   - Test failures
-4. Commit fixes with message: "fix: resolve issues from {package} update"
-5. Ensure CI is green before approving
-6. After PR is merged or skipped:
-   - Go to the Dependency Dashboard issue
-   - Check the box for the next update to process
-   - Wait for Renovate to create/rebase the PR
-
-### 6. Example Escalation Comment
-```
-@eins78 I need your input on this update:
-
-**Package**: example-package v2.0.0 → v3.0.0
-**Breaking Changes**:
-- Removed `oldMethod()` - we use this in 3 files
-- Changed default behavior of `configure()` 
-
-**My Analysis**:
-- We could migrate to `newMethod()` but it has different parameters
-- The configuration change might affect our production behavior
-
-**Recommendation**: [Approve/Delay/Skip] because...
-```
-
-### 7. Complete Workflow Summary
-
-1. **Start**: Check Dependency Dashboard for pending updates
-2. **Process**: Work on ONE PR at a time:
-   - Try to fix and merge (for safe updates)
-   - Or skip with @eins78 mention (for complex updates)
-3. **Next**: Via Dependency Dashboard, request next PR
-4. **Repeat**: Continue until Dashboard shows zero pending updates
-5. **Done**: All dependencies are either updated or escalated
-
-**Remember**: Your work is NOT complete until every single update is handled!
+**Key points:**
+- Process ALL updates until Dependency Dashboard is clear
+- Work on ONE PR at a time due to pnpm lockfile conflicts
+- Either merge (after fixing CI) or skip (escalate to @eins78)
+- Never stop until all updates are handled
 
 ## Getting Help
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,6 +373,72 @@ act  # Requires act tool to run GitHub Actions locally
 - `eslint.config.mjs`: Code style rules
 - `pnpm-workspace.yaml`: Monorepo configuration
 
+## Renovate PR Handling
+
+When handling automated Renovate PRs, follow these guidelines:
+
+### 1. Identify Update Type
+- Check the PR description for update type (major/minor/patch)
+- Look for breaking changes section in PR body
+- Check linked changelog/release notes
+
+### 2. Automated Approval Criteria
+
+#### Auto-approve and merge if ALL conditions are met:
+- Update type is minor or patch
+- All CI checks pass (after your fixes)
+- No breaking changes mentioned
+- Not in the special handling list below
+
+#### For Major Updates:
+1. Always check the linked changelog/release notes
+2. Search codebase for usage of changed APIs
+3. Auto-approve if:
+   - Breaking changes don't affect our code
+   - You can fix any issues that arise
+   - Changes are well-documented
+
+### 3. Special Package Rules
+
+#### High Priority Packages (always review carefully):
+- `lit`, `@lit/*`, `@lit-labs/*` - Core framework, check for API changes
+- `typescript` - May introduce new strict checks
+- `eslint` and plugins - May add new rules requiring fixes
+- `playwright` - Check for API changes in test code
+
+#### When to Escalate to @eins78:
+- Breaking changes that require architectural decisions
+- Security-related updates with unclear impact
+- Updates that fail after multiple fix attempts
+- License changes
+- Packages not in our approved list
+
+### 4. Fix Process
+1. Run `pnpm install` to update lockfile
+2. Run `pnpm run ci` to check everything
+3. Fix issues in this order:
+   - TypeScript errors
+   - Linting issues (use `pnpm run lint:eslint -- --fix`)
+   - Test failures
+4. Commit fixes with message: "fix: resolve issues from {package} update"
+5. Ensure CI is green before approving
+
+### 5. Example Escalation Comment
+```
+@eins78 I need your input on this update:
+
+**Package**: example-package v2.0.0 → v3.0.0
+**Breaking Changes**:
+- Removed `oldMethod()` - we use this in 3 files
+- Changed default behavior of `configure()` 
+
+**My Analysis**:
+- We could migrate to `newMethod()` but it has different parameters
+- The configuration change might affect our production behavior
+
+**Recommendation**: [Approve/Delay/Skip] because...
+```
+
 ## Getting Help
 
 - Check CI logs for specific error messages

--- a/RENOVATE.md
+++ b/RENOVATE.md
@@ -1,0 +1,115 @@
+# Renovate PR Handling Guide
+
+This document contains specific instructions for handling automated Renovate dependency update PRs.
+
+## 🎯 Ultimate Goal
+
+**Your mission: Process ALL pending dependency updates until the Dependency Dashboard is clear.**
+
+- Continue working through PRs one by one until every update is either:
+  - ✅ Merged (CI green, no issues)
+  - ⏭️ Skipped (escalated to @eins78)
+- Do NOT stop work until all updates are handled
+- The Dependency Dashboard should show zero pending updates when you're done
+
+## 1. Identify Update Type
+- Check the PR description for update type (major/minor/patch)
+- Look for breaking changes section in PR body
+- Check linked changelog/release notes
+
+## 2. 🚨 CRITICAL: One PR at a Time Rule
+
+**Due to pnpm lockfile conflicts, you MUST only work on ONE dependency update at a time:**
+
+1. **Never work on multiple Renovate PRs simultaneously**
+2. **Never request rebase for more than one PR**
+3. **Follow this workflow:**
+   - Work on one PR until it's either merged or skipped
+   - Only after completion, use the Dependency Dashboard issue
+   - Check the box to request the next update or rebase
+   - Wait for the new PR before starting work
+
+**Why this matters:** Every dependency update modifies the pnpm lockfile, causing merge conflicts with all other update PRs. Working on multiple PRs wastes effort as only one can be merged.
+
+## 3. Automated Approval Criteria
+
+### Auto-approve and merge if ALL conditions are met:
+- Update type is minor or patch
+- All CI checks pass (after your fixes)
+- No breaking changes mentioned
+- Not in the special handling list below
+
+### For Major Updates:
+1. Always check the linked changelog/release notes
+2. Search codebase for usage of changed APIs
+3. Auto-approve if:
+   - Breaking changes don't affect our code
+   - You can fix any issues that arise
+   - Changes are well-documented
+
+## 4. Special Package Rules
+
+### High Priority Packages (always review carefully):
+- `lit`, `@lit/*`, `@lit-labs/*` - Core framework, check for API changes
+- `typescript` - May introduce new strict checks
+- `eslint` and plugins - May add new rules requiring fixes
+- `playwright` - Check for API changes in test code
+
+### When to Skip (Escalate to @eins78):
+
+**Skip the PR and mention @eins78 when:**
+- Breaking changes require architectural decisions (e.g., API redesign, migration strategy)
+- Security updates have unclear impact on our application
+- After 3 attempts, you cannot make CI green
+- License changes from permissive to restrictive
+- Package is not in our dependencies (might be a new sub-dependency)
+- Update requires manual testing that you cannot perform
+- Breaking changes affect core business logic you're unsure about
+
+**When you skip:** 
+1. Comment with the escalation format (see example below)
+2. Do NOT close or dismiss the PR
+3. Move to the next update via Dependency Dashboard
+4. Continue processing other updates
+
+## 5. Fix Process
+1. Run `pnpm install` to update lockfile
+2. Run `pnpm run ci` to check everything
+3. Fix issues in this order:
+   - TypeScript errors
+   - Linting issues (use `pnpm run lint:eslint -- --fix`)
+   - Test failures
+4. Commit fixes with message: "fix: resolve issues from {package} update"
+5. Ensure CI is green before approving
+6. After PR is merged or skipped:
+   - Go to the Dependency Dashboard issue
+   - Check the box for the next update to process
+   - Wait for Renovate to create/rebase the PR
+
+## 6. Example Escalation Comment
+```
+@eins78 I need your input on this update:
+
+**Package**: example-package v2.0.0 → v3.0.0
+**Breaking Changes**:
+- Removed `oldMethod()` - we use this in 3 files
+- Changed default behavior of `configure()` 
+
+**My Analysis**:
+- We could migrate to `newMethod()` but it has different parameters
+- The configuration change might affect our production behavior
+
+**Recommendation**: [Approve/Delay/Skip] because...
+```
+
+## 7. Complete Workflow Summary
+
+1. **Start**: Check Dependency Dashboard for pending updates
+2. **Process**: Work on ONE PR at a time:
+   - Try to fix and merge (for safe updates)
+   - Or skip with @eins78 mention (for complex updates)
+3. **Next**: Via Dependency Dashboard, request next PR
+4. **Repeat**: Continue until Dashboard shows zero pending updates
+5. **Done**: All dependencies are either updated or escalated
+
+**Remember**: Your work is NOT complete until every single update is handled!

--- a/RENOVATE.md
+++ b/RENOVATE.md
@@ -38,7 +38,7 @@ This document contains specific instructions for handling automated Renovate dep
 - All CI checks pass (after your fixes)
 - No breaking changes mentioned
 - Not in the special handling list below
-- Merge confidence is not LOW (see section below)
+- Merge confidence is not LOW (see Section 4: Understanding Merge Confidence)
 
 ### For Major Updates:
 1. Always check the linked changelog/release notes
@@ -91,7 +91,7 @@ Renovate provides merge confidence badges to help assess update safety:
 ## 6. Fix Process
 
 ### What You CAN Fix:
-1. Run `pnpm install` to update lockfile
+1. Run `pnpm install` if needed (Renovate usually updates the lockfile, but run this if you see lockfile errors)
 2. Run `pnpm run ci` to check everything
 3. Fix these types of issues:
    - TypeScript errors (update types, fix imports)

--- a/RENOVATE.md
+++ b/RENOVATE.md
@@ -89,18 +89,31 @@ Renovate provides merge confidence badges to help assess update safety:
 4. Continue processing other updates
 
 ## 6. Fix Process
+
+### What You CAN Fix:
 1. Run `pnpm install` to update lockfile
 2. Run `pnpm run ci` to check everything
-3. Fix issues in this order:
-   - TypeScript errors
+3. Fix these types of issues:
+   - TypeScript errors (update types, fix imports)
    - Linting issues (use `pnpm run lint:eslint -- --fix`)
-   - Test failures
+   - Simple test failures (update snapshots, fix assertions)
+   - Build configuration issues
 4. Commit fixes with message: "fix: resolve issues from {package} update"
-5. Ensure CI is green before approving
-6. After PR is merged or skipped:
-   - Go to the Dependency Dashboard issue
-   - Check the box for the next update to process
-   - Wait for Renovate to create/rebase the PR
+5. Push and wait for CI to run
+
+### What You CANNOT Fix (Escalate to @eins78):
+- Tests that require running the application locally
+- Issues that need manual browser testing
+- Errors that require debugging with `pnpm run dev`
+- Complex test failures that need investigation
+- Any situation where you need to execute the project
+
+### Workflow Behavior:
+- **You have 60 minutes per run** to fix issues
+- **Automatic re-runs**: The workflow checks every hour for Renovate PRs with failing CI
+- **One at a time**: Only one Claude instance runs at a time (no parallel execution)
+- If CI is still failing after your fixes, the workflow will automatically retry in the next hourly check
+- For complex issues that need immediate attention, mention @eins78
 
 ## 7. Example Escalation Comment
 ```

--- a/RENOVATE.md
+++ b/RENOVATE.md
@@ -38,6 +38,7 @@ This document contains specific instructions for handling automated Renovate dep
 - All CI checks pass (after your fixes)
 - No breaking changes mentioned
 - Not in the special handling list below
+- Merge confidence is not LOW (see section below)
 
 ### For Major Updates:
 1. Always check the linked changelog/release notes
@@ -47,7 +48,22 @@ This document contains specific instructions for handling automated Renovate dep
    - You can fix any issues that arise
    - Changes are well-documented
 
-## 4. Special Package Rules
+## 4. Understanding Merge Confidence
+
+Renovate provides merge confidence badges to help assess update safety:
+
+### Confidence Levels:
+- **✅ HIGH/VERY HIGH**: Very low chance of breaking changes, generally safe to merge
+- **➖ NEUTRAL**: Insufficient data, proceed with normal caution
+- **⚠️ LOW/VERY LOW**: Higher risk of issues, often expected for major updates
+
+### How to Use:
+- **HIGH confidence + PATCH/MINOR**: Strong signal to merge after CI passes
+- **LOW confidence + MAJOR**: Expected, review breaking changes carefully
+- **LOW confidence + PATCH/MINOR**: Unusual, investigate why (might have hidden breaking changes)
+- Always run CI regardless of confidence level
+
+## 5. Special Package Rules
 
 ### High Priority Packages (always review carefully):
 - `lit`, `@lit/*`, `@lit-labs/*` - Core framework, check for API changes
@@ -72,7 +88,7 @@ This document contains specific instructions for handling automated Renovate dep
 3. Move to the next update via Dependency Dashboard
 4. Continue processing other updates
 
-## 5. Fix Process
+## 6. Fix Process
 1. Run `pnpm install` to update lockfile
 2. Run `pnpm run ci` to check everything
 3. Fix issues in this order:
@@ -86,7 +102,7 @@ This document contains specific instructions for handling automated Renovate dep
    - Check the box for the next update to process
    - Wait for Renovate to create/rebase the PR
 
-## 6. Example Escalation Comment
+## 7. Example Escalation Comment
 ```
 @eins78 I need your input on this update:
 
@@ -102,7 +118,7 @@ This document contains specific instructions for handling automated Renovate dep
 **Recommendation**: [Approve/Delay/Skip] because...
 ```
 
-## 7. Complete Workflow Summary
+## 8. Complete Workflow Summary
 
 1. **Start**: Check Dependency Dashboard for pending updates
 2. **Process**: Work on ONE PR at a time:


### PR DESCRIPTION
## Summary
- Automated Claude integration for Renovate dependency update PRs
- No manual @claude comments needed - workflow triggers automatically
- Smart handling based on update type (major vs minor/patch)

## Changes
1. **New workflow: `.github/workflows/claude-renovate.yml`**
   - Triggers automatically on Renovate PRs
   - Posts contextual instructions to Claude
   - Uses same auth token as existing claude.yml
   
2. **Enhanced CLAUDE.md documentation**
   - Added "Renovate PR Handling" section
   - Clear criteria for auto-approval vs escalation
   - Special handling rules for critical packages
   - Example escalation format

## How it works
1. Renovate creates a PR
2. Workflow detects `renovate[bot]` as actor
3. Automatically comments with @claude mention
4. Claude follows instructions in CLAUDE.md to:
   - Fix CI issues for minor/patch updates
   - Analyze breaking changes for major updates
   - Escalate to @eins78 when needed

## Test plan
- [ ] Workflow syntax is valid
- [ ] Will trigger on next Renovate PR
- [ ] Instructions in CLAUDE.md are clear and actionable

🤖 Generated with [Claude Code](https://claude.ai/code)