### PR TITLE
fix: docker e2e tests failing on main

### DIFF
--- a/.github/workflows/docker-e2e-tests.yml
+++ b/.github/workflows/docker-e2e-tests.yml
@@ -62,7 +62,7 @@ jobs:
         working-directory: ./packages/e2e-tests
 
       - name: Run Playwright tests
-        run: pnpm run e2e
+        run: pnpm run e2e --project=chromium
         working-directory: ./packages/e2e-tests
         env:
           PORT: 8080

--- a/.github/workflows/docker-e2e-tests.yml
+++ b/.github/workflows/docker-e2e-tests.yml
@@ -1,3 +1,14 @@
+# Docker End-to-End Tests
+#
+# This workflow runs e2e tests against the Docker container.
+# It is triggered by:
+# - workflow_run: After "Docker Image Publish" completes successfully
+#   (this reuses the Docker build cache from the previous workflow)
+# - workflow_dispatch: Manual trigger for testing
+#
+# The workflow builds the Docker image locally, runs the container,
+# and executes Playwright e2e tests against it.
+
 name: Docker End-to-End Tests
 
 on:

--- a/.github/workflows/docker-e2e-tests.yml
+++ b/.github/workflows/docker-e2e-tests.yml
@@ -35,7 +35,10 @@ jobs:
 
       - name: Run Docker container
         run: |
-          docker run -d -p 8080:7777 --name lit-ssr-demo ghcr.io/${{ github.repository }}:local-test
+          docker run -d -p 8080:8080 --name lit-ssr-demo \
+            -e PORT=8080 \
+            -e 'APP_TITLE=Hello World!' \
+            ghcr.io/${{ github.repository }}:local-test
           # Wait for container to be healthy
           sleep 10
 
@@ -64,6 +67,7 @@ jobs:
         env:
           PORT: 8080
           CI: true
+          SKIP_WEB_SERVER: true
 
       - name: Upload Playwright Report
         if: ${{ always() && env.ACTIONS_RUNTIME_TOKEN != '' }}

--- a/.github/workflows/docker-e2e-tests.yml
+++ b/.github/workflows/docker-e2e-tests.yml
@@ -4,18 +4,21 @@ on:
   workflow_run:
     workflows: ["Docker Image Publish"]
     types: [completed]
+  workflow_dispatch:
 
 jobs:
   docker-e2e:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Skip if workflow_run and previous workflow failed
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           # For workflow_run events, we need to explicitly checkout the PR code
-          ref: ${{ github.event.workflow_run.head_sha }}
+          # For workflow_dispatch, use the current branch
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.workflow_run.head_sha }}
 
       - name: Build Docker image locally
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-e2e-tests.yml
+++ b/.github/workflows/docker-e2e-tests.yml
@@ -35,10 +35,7 @@ jobs:
 
       - name: Run Docker container
         run: |
-          docker run -d -p 8080:8080 --name lit-ssr-demo \
-            -e PORT=8080 \
-            -e 'APP_TITLE=Hello World!' \
-            ghcr.io/${{ github.repository }}:local-test
+          docker run -d -p 8080:8080 --name lit-ssr-demo -e PORT=8080 -e APP_TITLE="Hello World!" ghcr.io/${{ github.repository }}:local-test
           # Wait for container to be healthy
           sleep 10
 

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -9,6 +9,7 @@ on:
     tags:
       - "v*.*.*"
   pull_request: {}
+  workflow_dispatch:
 
 jobs:
   docker-build:

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -1,3 +1,16 @@
+# Docker Image Build and Publish
+#
+# This workflow builds the Docker image and publishes it to GHCR.
+# It runs on:
+# - Pull requests (to validate Docker builds)
+# - Push to main branch (to publish main image)
+# - Version tags (to publish release images)
+# - Daily schedule (to keep base images updated)
+# - Manual trigger via workflow_dispatch
+#
+# The docker-e2e-tests.yml workflow is triggered after this completes successfully,
+# which reuses the built image cache to avoid building twice in parallel.
+
 name: Docker Image Publish
 
 on:

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -11,7 +11,7 @@ const testDir = defineBddConfig({
 // Choose server command based on Node.js version
 const nodeVersion = process.version;
 const [major, minor] = nodeVersion.slice(1).split(".").map(Number);
-const hasExperimentalFlags = major > 22 || (major === 22 && minor >= 7);
+const hasExperimentalFlags = major && (major > 22 || (major === 22 && minor && minor >= 7));
 const serverCommand = hasExperimentalFlags
   ? "cd ../../packages/app && node --experimental-strip-types --experimental-transform-types src/bin/www.ts"
   : "cd ../../packages/app && pnpm exec tsx src/bin/www.ts";
@@ -46,14 +46,17 @@ export default defineConfig({
     },
   ],
 
-  webServer: {
-    command: serverCommand,
-    port: Number(PORT),
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
-    env: {
-      DEBUG: "hello-world-web:*",
-      NODE_ENV: "production",
-    },
-  },
+  // Skip webServer if testing against external server (e.g., Docker container)
+  webServer: process.env.SKIP_WEB_SERVER
+    ? undefined
+    : {
+        command: serverCommand,
+        port: Number(PORT),
+        reuseExistingServer: !process.env.CI,
+        timeout: 120 * 1000,
+        env: {
+          DEBUG: "hello-world-web:*",
+          NODE_ENV: "production",
+        },
+      },
 });


### PR DESCRIPTION
## Summary

Fixes the Docker end-to-end tests that were failing on main.

## Changes

- **Add `SKIP_WEB_SERVER` env var**: Playwright config now conditionally skips starting its own webServer when testing against an external server (Docker container)
- **Configure Docker container env vars**: Set `PORT=8080` and `APP_TITLE="Hello World!"` to match test expectations  
- **Run only Chromium tests**: Docker e2e workflow only installs chromium browser, so limit tests to `--project=chromium`
- **Add `workflow_dispatch` triggers**: Both Docker workflows can now be manually triggered for easier testing
- **Fix TypeScript diagnostics**: Added proper undefined checks in playwright.config.ts
- **Documentation**: Added explanatory comments to workflow files clarifying the relationship between `docker-image-publish` and `docker-e2e-tests`

## Root Cause

The docker-e2e-tests workflow was failing because:

1. Playwright was trying to start its own webServer on port 8080, which conflicted with the already-running Docker container
2. The workflow ran tests for all 3 browsers (chromium, firefox, webkit) but only installed chromium
3. Missing env var configuration meant the container ran on wrong port/title

## Testing

- ✅ Manual workflow trigger succeeded: https://github.com/eins78/hello-world-web/actions/runs/18343515781
- CI will run automatically on this PR to verify both workflows work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)