### PR TITLE
fix(ci): ensure Docker image only publishes after E2E tests pass

### DIFF
--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   docker-build:
     # Only run if workflow_run was successful, or if triggered by other events
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Changes the docker-image-publish workflow to wait for docker-e2e-tests to complete successfully before publishing on the main branch.

**Before:**
- merge to main → docker-e2e-tests (in parallel with) docker-image-publish

**After:**
- merge to main → docker-e2e-tests → docker-image-publish (only if tests pass)

This ensures we never publish a broken Docker image to production registries.

Other triggers (PR validation, tags, scheduled, manual) remain unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)