### PR TITLE
feat: add dependency diff analysis workflow

### DIFF
--- a/.github/workflows/dependency-diff.yml
+++ b/.github/workflows/dependency-diff.yml
@@ -1,0 +1,38 @@
+name: Dependency Diff Analysis
+
+# This workflow analyzes dependency changes in PRs using action-dependency-diff.
+# It detects security/maintenance issues: trust degradation, dependency bloat,
+# size growth, version duplication, and suggests alternatives.
+# Runs on all PRs to catch both Renovate and human-introduced changes.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  dependency-diff:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Need history to compare against base
+
+      - name: Run Dependency Diff Analysis
+        uses: e18e/action-dependency-diff@d8853a053c2a8a2a428eee0edbaa4f8934f55cdb # Latest as of 2025-11-02
+        with:
+          github-token: ${{ github.token }}
+          pr-number: ${{ github.event.pull_request.number }}
+          # Alert if >10 dependencies added (reasonable for most updates)
+          dependency-threshold: 10
+          # Alert if total size grows >100KB (default, appropriate for this project)
+          size-threshold: 100000
+          # Flag packages installed in multiple versions
+          duplicate-threshold: 1
+          # Suggest better package alternatives
+          detect-replacements: true


### PR DESCRIPTION
Add action-dependency-diff to analyze dependency changes in PRs. Detects security/maintenance issues:
- Package trust degradation
- Dependency bloat (>10 packages)
- Size growth (>100KB)
- Version duplication
- Suggests better alternatives

Runs on all PRs (Renovate and human) to provide early feedback alongside existing Claude reviews.