### PR TITLE
chore(deps): dedupe prettier — option B (pnpm.overrides)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@lit/reactive-element": "2.1.2"
+      "@lit/reactive-element": "2.1.2",
+      "prettier": "^3.9.4"
     }
   },
   "packageManager": "pnpm@10.34.4+sha512.8768be55200ae3f2226b6527fcca2687e14bc4e5f12d7721a0f25da3df47915177058648db4177baf348120fa0ba2752d8d8d93f6beaf1fe64ae18da8de961af"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 
 overrides:
   '@lit/reactive-element': 2.1.2
+  prettier: ^3.9.4
 
 importers:
 
@@ -64,7 +65,7 @@ importers:
         specifier: ^8.0.0
         version: 8.0.4
       prettier:
-        specifier: ^3.3.3
+        specifier: ^3.9.4
         version: 3.9.4
       realpath:
         specifier: ^3.0.0
@@ -1411,7 +1412,7 @@ packages:
       '@types/eslint': '>=8.0.0'
       eslint: '>=8.0.0'
       eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
-      prettier: '>=3.0.0'
+      prettier: ^3.9.4
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -2160,11 +2161,6 @@ packages:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
-  prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-
   prettier@3.9.4:
     resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
     engines: {node: '>=14'}
@@ -2583,7 +2579,7 @@ snapshots:
       fs-extra: 7.0.1
       lodash.startcase: 4.4.0
       outdent: 0.5.0
-      prettier: 2.8.8
+      prettier: 3.9.4
       resolve-from: 5.0.0
       semver: 7.7.4
 
@@ -2727,7 +2723,7 @@ snapshots:
       '@changesets/types': 6.1.0
       fs-extra: 7.0.1
       human-id: 4.1.3
-      prettier: 2.8.8
+      prettier: 3.9.4
 
   '@colors/colors@1.5.0':
     optional: true
@@ -4560,8 +4556,6 @@ snapshots:
   prettier-linter-helpers@1.0.1:
     dependencies:
       fast-diff: 1.3.0
-
-  prettier@2.8.8: {}
 
   prettier@3.9.4: {}
 


### PR DESCRIPTION
## Summary

Deduplicates `prettier` from 2 versions down to 1 using `pnpm.overrides`.

## Why

`@changesets/apply-release-plan@7.1.1` and `@changesets/write@0.4.0` both hard-code `"prettier": "^2.7.1"` as a **direct** dependency (not a peer), causing pnpm to install both `prettier@2.8.8` and `prettier@3.9.4` simultaneously.

**Option C (preferred) was attempted first** — checking whether any stable `@changesets/cli` release drops the prettier@2 dep. Result: no stable version does. The v3 pre-release series (`3.0.0-next.8`) uses prettier-free sub-packages, but it's not yet stable. **Falling back to Option B.**

## Changes

Added `"prettier": "^3.9.4"` to the existing `pnpm.overrides` block in root `package.json` (merged alongside the existing `@lit/reactive-element` override, not replaced):

```json
"pnpm": {
  "overrides": {
    "@lit/reactive-element": "2.1.2",
    "prettier": "^3.9.4"
  }
}
```

## Before / After

**Before** (`pnpm why prettier`):
```
prettier@2.8.8
├─┬ @changesets/apply-release-plan@7.1.1
│ └─┬ @changesets/cli@2.31.0
└─┬ @changesets/write@0.4.0
  └── @changesets/cli@2.31.0 [deduped]

prettier@3.9.4
├── @hello-world-web/workspace (devDependencies)
└─┬ eslint-plugin-prettier
  └── @hello-world-web/workspace (devDependencies)

Found 2 versions of prettier
```

**After** (`pnpm why prettier`):
```
prettier@3.9.4
├─┬ @changesets/apply-release-plan@7.1.1
│ └─┬ @changesets/cli@2.31.0
├─┬ @changesets/write@0.4.0
│ └── @changesets/cli@2.31.0 [deduped]
├── @hello-world-web/workspace (devDependencies)
└─┬ eslint-plugin-prettier
  └── @hello-world-web/workspace (devDependencies)

Found 1 version of prettier
```

## Scope

- `node-fetch@2+3` duplication and `node-domexception` deprecation are **intentionally not addressed** — those are deferred (option D per Max's directive; different package ecosystems, no build impact.
-  and Scope: all 4 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date

Done in 381ms using pnpm v10.34.4

> @hello-world-web/workspace@2.0.0-rc.3 build /Users/user/CODE/hello-world-web/.claude/worktrees/renovate-prs
> pnpm -r run build

Scope: 3 of 4 workspace projects
packages/lit-ssr-demo build$ rollup -c
packages/lit-ssr-demo build: [36m
packages/lit-ssr-demo build: [1msrc/entry-client.ts[22m → [1mlib/client/[22m...[39m
packages/lit-ssr-demo build: [32mcreated [1mlib/client/[22m in [1m526ms[22m[39m
packages/lit-ssr-demo build: [36m
packages/lit-ssr-demo build: [1msrc/entry-server.ts[22m → [1mlib/server/entry-server.js[22m...[39m
packages/lit-ssr-demo build: [32mcreated [1mlib/server/entry-server.js[22m in [1m285ms[22m[39m
packages/lit-ssr-demo build: Done pass locally.  has a pre-existing local failure due to the git worktree at  confusing knip — this does not affect CI.

## Risk

Low. Changesets uses prettier for changelog file formatting. The  v2→v3 formatting API is backward-compatible for the subset of operations changesets uses ( /  on markdown). If changeset commands break, revert is trivial (remove the override line).

---

Ready for review. Do not merge autonomously — awaiting Max's decision.
EOF
)