### PR TITLE
chore(deps): dedupe node-fetch + drop deprecated node-domexception chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
   "pnpm": {
     "overrides": {
       "@lit/reactive-element": "2.1.2",
-      "prettier": "^3.9.4"
+      "prettier": "^3.9.4",
+      "node-fetch": "^2.7.0"
     }
   },
   "packageManager": "pnpm@10.34.4+sha512.8768be55200ae3f2226b6527fcca2687e14bc4e5f12d7721a0f25da3df47915177058648db4177baf348120fa0ba2752d8d8d93f6beaf1fe64ae18da8de961af"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ settings:
 overrides:
   '@lit/reactive-element': 2.1.2
   prettier: ^3.9.4
+  node-fetch: ^2.7.0
 
 importers:
 
@@ -1281,10 +1282,6 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
-
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
 
@@ -1528,10 +1525,6 @@ packages:
       picomatch:
         optional: true
 
-  fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1576,10 +1569,6 @@ packages:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
     engines: {node: '>=18.3.0'}
     hasBin: true
-
-  formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1972,11 +1961,6 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -1985,10 +1969,6 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
-
-  node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   nodemon@3.1.14:
     resolution: {integrity: sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==}
@@ -2520,10 +2500,6 @@ packages:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
 
-  web-streams-polyfill@3.3.3:
-    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
-    engines: {node: '>= 8'}
-
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -2992,10 +2968,12 @@ snapshots:
       lit: 3.3.3
       lit-element: 4.2.1
       lit-html: 3.3.3
-      node-fetch: 3.3.2
+      node-fetch: 2.7.0
       parse5: 7.2.1
     optionalDependencies:
       '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - encoding
 
   '@lit/reactive-element@2.1.2':
     dependencies:
@@ -3644,8 +3622,6 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  data-uri-to-buffer@4.0.1: {}
-
   dataloader@1.4.0: {}
 
   debug@2.6.9:
@@ -3943,11 +3919,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  fetch-blob@3.2.0:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.3
-
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -3999,10 +3970,6 @@ snapshots:
   formatly@0.3.0:
     dependencies:
       fd-package-json: 2.0.0
-
-  formdata-polyfill@4.0.10:
-    dependencies:
-      fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
 
@@ -4361,17 +4328,9 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  node-domexception@1.0.0: {}
-
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-
-  node-fetch@3.3.2:
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
 
   nodemon@3.1.14:
     dependencies:
@@ -4936,8 +4895,6 @@ snapshots:
       - debug
 
   walk-up-path@4.0.0: {}
-
-  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
## Summary

Resolves two open duplicate-dep cases via `pnpm.overrides`, fixing both with a single override entry.

## Cases addressed

**Case 1: `node-fetch@2.7.0` + `node-fetch@3.3.2`**
- v2 pulled by: `@changesets/get-github-info@0.8.0` (CJS `require('node-fetch')`)
- v3 pulled by: `@lit-labs/ssr@4.1.0` (ESM `import fetch from 'node-fetch'` for DOM shim)

**Case 2: `node-domexception@1.0.0` (deprecated)**
- Chain: `@lit-labs/ssr` → `node-fetch@3` → `fetch-blob@3.2.0` → `node-domexception`

## What was tried

**Option C (upstream upgrade) — not viable:**
- `@changesets/get-github-info@1.0.0-next.3` drops node-fetch entirely — pre-release only
- `@changesets/cli@3.0.0-next.8` pulls in the fixed version — pre-release only
- `@lit-labs/ssr@4.1.0` is current stable; no stable version uses native fetch

**Option B (pnpm.overrides) — applied:**

Added `node-fetch: ^2.7.0` to existing `pnpm.overrides` block.

Why forcing v2 (not v3) is safe:
- `@changesets/get-github-info` already uses v2 natively ✓
- `@lit-labs/ssr` only imports the `fetch` *function* (not `Response`, `Request`, or any v3-specific class) — confirmed by reading `lib/dom-shim.js`
- ESM `import fetch from 'node-fetch'` on a CJS module (v2) gets the default export via Node interop ✓
- Project requires Node >=22.7.0, which has native `globalThis.fetch` — the node-fetch polyfill is a fallback that rarely fires

Side-effect: eliminating node-fetch@3 removes the `fetch-blob` + `node-domexception` chain entirely (Case 2 resolved for free).

Forcing v3 was **not** attempted — `@changesets/get-github-info` uses CJS `require('node-fetch')` which fails with `ERR_REQUIRE_ESM` on node-fetch@3.

## Before / After

**Before:**
```
# pnpm why node-fetch (packages/app):
node-fetch@2.7.0  (changesets chain)
node-fetch@3.3.2  (@lit-labs/ssr)
Found 2 versions of node-fetch

# pnpm why node-domexception:
node-domexception@1.0.0 (deprecated)
└── fetch-blob@3.2.0
    └── node-fetch@3.3.2
        └── @lit-labs/ssr@4.1.0
```

**After:**
```
# pnpm why node-fetch (all workspace packages):
node-fetch@2.7.0
Found 1 version of node-fetch

# node-domexception: not installed (removed from lockfile)
```

## Scope

- `prettier` deduplication is in the parallel PR #487 (separate concern)
- Lint (`eslint`, `shellcheck`) and `build` pass locally
- `lint:knip` has a pre-existing local failure due to git worktree at `.claude/worktrees/` — not caused by this change, does not affect CI

---

Ready for review. Do not merge autonomously — awaiting Max's decision.